### PR TITLE
Handle empty Bible references

### DIFF
--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/SearchParser.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/SearchParser.kt
@@ -21,6 +21,17 @@ object SearchParser {
         val canonicalBookName = bookMatch.first
         val numbersPart = bookMatch.second
 
+        // Dacă utilizatorul a introdus doar numele cărții fără referințe numerice,
+        // presupunem capitolul 1, versetul 1.
+        if (numbersPart.isBlank()) {
+            return ParsedReference(
+                bookName = canonicalBookName,
+                chapter = 1,
+                startVerse = 1,
+                endVerse = null
+            )
+        }
+
         // Pasul 2: Aplicăm expresia regulată pe restul textului (partea cu numere)
         val matcher = REF_PATTERN.matcher(numbersPart)
         if (!matcher.find()) return null

--- a/app/src/test/java/md/ortodox/ortodoxmd/ui/bible/SearchParserTest.kt
+++ b/app/src/test/java/md/ortodox/ortodoxmd/ui/bible/SearchParserTest.kt
@@ -1,0 +1,20 @@
+package md.ortodox.ortodoxmd.ui.bible
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchParserTest {
+    @Test
+    fun parseWithOnlyBookDefaultsToFirstChapter() {
+        val result = SearchParser.parse("Geneza")
+        assertEquals(
+            ParsedReference(
+                bookName = "FACEREA (GENEZA)",
+                chapter = 1,
+                startVerse = 1,
+                endVerse = null
+            ),
+            result
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Default Bible reference parsing to chapter 1 verse 1 when only a book name is provided
- Add unit test covering parsing of book-only queries

