### PR TITLE
Localize more UI strings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,4 +126,5 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     implementation(libs.coil.compose)
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 }

--- a/app/src/main/java/md/ortodox/ortodoxmd/data/di/PreferencesModule.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/data/di/PreferencesModule.kt
@@ -1,0 +1,19 @@
+package md.ortodox.ortodoxmd.data.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import md.ortodox.ortodoxmd.data.preferences.LanguagePreferences
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+    @Provides
+    @Singleton
+    fun provideLanguagePreferences(@ApplicationContext context: Context): LanguagePreferences =
+        LanguagePreferences(context)
+}

--- a/app/src/main/java/md/ortodox/ortodoxmd/data/preferences/LanguagePreferences.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/data/preferences/LanguagePreferences.kt
@@ -1,0 +1,29 @@
+package md.ortodox.ortodoxmd.data.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private val Context.dataStore by preferencesDataStore(name = "settings")
+
+class LanguagePreferences @Inject constructor(@ApplicationContext private val context: Context) {
+    companion object {
+        private val LANGUAGE = stringPreferencesKey("language")
+    }
+
+    val language: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[LANGUAGE] ?: "ro"
+    }
+
+    suspend fun setLanguage(lang: String) {
+        context.dataStore.edit { prefs: Preferences ->
+            prefs[LANGUAGE] = lang
+        }
+    }
+}

--- a/app/src/main/java/md/ortodox/ortodoxmd/notifications/NotificationHelper.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/notifications/NotificationHelper.kt
@@ -17,8 +17,8 @@ object NotificationHelper {
 
     fun createNotificationChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val name = "Notificări Calendar Zilnic"
-            val descriptionText = "Afișează informațiile zilnice din calendarul ortodox."
+            val name = context.getString(R.string.notification_daily_calendar_channel_name)
+            val descriptionText = context.getString(R.string.notification_daily_calendar_channel_description)
             val importance = NotificationManager.IMPORTANCE_DEFAULT
             val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
                 description = descriptionText

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/anuar/AnuarScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/anuar/AnuarScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import md.ortodox.ortodoxmd.data.model.LiturgicalService
 import java.time.LocalDate
@@ -45,11 +46,12 @@ private fun rememberParsedText(rawText: String?): List<ContentBlock> {
 }
 
 // Funcție pentru a asocia un tip de slujbă cu un nume și o pictogramă
+@Composable
 private fun mapServiceType(type: String): Pair<String, ImageVector> {
     return when (type.lowercase()) {
-        "vespers" -> "Vecernie" to Icons.Default.WbTwilight
-        "matins" -> "Utrenie" to Icons.Default.WbSunny
-        "liturgy" -> "Sfânta Liturghie" to Icons.Default.Church
+        "vespers" -> stringResource(R.string.vespers) to Icons.Default.WbTwilight
+        "matins" -> stringResource(R.string.matins) to Icons.Default.WbSunny
+        "liturgy" -> stringResource(R.string.divine_liturgy) to Icons.Default.Church
         else -> type.replaceFirstChar { it.uppercase() } to Icons.Default.MenuBook
     }
 }
@@ -83,7 +85,7 @@ fun AnuarScreen(
                     CircularProgressIndicator()
                 }
                 uiState.services.isEmpty() -> Box(Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
-                    Text("Pentru această zi nu sunt disponibile rânduieli.", textAlign = TextAlign.Center)
+                    Text(stringResource(R.string.no_services), textAlign = TextAlign.Center)
                 }
                 else -> {
                     LazyColumn(
@@ -110,9 +112,9 @@ fun AnuarScreen(
                         viewModel.selectDate(selectedLocalDate)
                     }
                     showDatePicker = false
-                }) { Text("OK") }
+                }) { Text(stringResource(R.string.ok)) }
             },
-            dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("Anulează") } }
+            dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text(stringResource(R.string.cancel)) } }
         ) {
             DatePicker(state = datePickerState)
         }
@@ -138,13 +140,13 @@ private fun DateSelectorBar(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             IconButton(onClick = onPreviousDay) {
-                Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, "Ziua precedentă")
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, stringResource(R.string.previous_day))
             }
             TextButton(onClick = onDateClick) {
                 Text(formattedDate, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             }
             IconButton(onClick = onNextDay) {
-                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Ziua următoare")
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, stringResource(R.string.next_day))
             }
         }
     }
@@ -168,7 +170,7 @@ private fun ServiceCard(service: LiturgicalService) {
             Divider(modifier = Modifier.padding(vertical = 12.dp))
 
             if (parsedDetails.isEmpty()) {
-                Text("Nu sunt detalii pentru această slujbă.", style = MaterialTheme.typography.bodyMedium)
+                Text(stringResource(R.string.no_service_details), style = MaterialTheme.typography.bodyMedium)
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     parsedDetails.forEach { block ->

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/apologetic/ApologeticScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/apologetic/ApologeticScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -33,8 +34,8 @@ fun ApologeticScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            placeholder = { Text("Caută un subiect...") },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Caută") },
+            placeholder = { Text(stringResource(R.string.apologetics_search_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.search)) },
             singleLine = true
         )
 
@@ -91,7 +92,7 @@ private fun ApologeticCard(apologetic: Apologetic) {
             ) {
                 Icon(
                     imageVector = Icons.Default.HelpOutline,
-                    contentDescription = "Întrebare",
+                    contentDescription = stringResource(R.string.question),
                     tint = MaterialTheme.colorScheme.secondary
                 )
                 Text(
@@ -101,7 +102,7 @@ private fun ApologeticCard(apologetic: Apologetic) {
                 )
                 Icon(
                     imageVector = Icons.Default.ExpandMore,
-                    contentDescription = "Extinde",
+                    contentDescription = stringResource(R.string.expand),
                     modifier = Modifier.rotate(rotationAngle)
                 )
             }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookBooksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookBooksScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import java.net.URLEncoder
@@ -55,7 +56,7 @@ fun AudiobookBooksScreen(
         topBar = {
             Log.d("AudiobookBooksScreen", "TopAppBar rendering with testamentName: $testamentName")
             TopAppBar(
-                title = { Text(testamentName.ifEmpty { "Cărți" }) },
+                title = { Text(testamentName.ifEmpty { stringResource(R.string.books) }) },
                 navigationIcon = {
                     Log.d("AudiobookBooksScreen", "Navigation icon rendering")
                     IconButton(
@@ -67,7 +68,7 @@ fun AudiobookBooksScreen(
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi",
+                            contentDescription = stringResource(R.string.back),
                             tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
@@ -110,7 +111,7 @@ fun AudiobookBooksScreen(
                             .padding(16.dp)
                             .clickable(
                                 enabled = true,
-                                onClickLabel = "Navighează la ${book.name}",
+                                onClickLabel = stringResource(R.string.navigate_to_book, book.name),
                                 onClick = {
                                     val encodedBookName = URLEncoder.encode(book.name, StandardCharsets.UTF_8.toString())
                                     navController.navigate("audiobook_chapters/$encodedBookName")
@@ -120,7 +121,7 @@ fun AudiobookBooksScreen(
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.LibraryBooks,
-                            contentDescription = "Icoană Carte",
+                            contentDescription = stringResource(R.string.book_icon_desc),
                             modifier = Modifier.size(40.dp),
                             tint = MaterialTheme.colorScheme.primary
                         )
@@ -135,7 +136,7 @@ fun AudiobookBooksScreen(
                         if (isHovered) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                contentDescription = "Navighează",
+                                contentDescription = stringResource(R.string.navigate),
                                 tint = MaterialTheme.colorScheme.secondary
                             )
                         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookCategoriesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookCategoriesScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import java.net.URLEncoder
@@ -47,7 +48,7 @@ fun AudiobookCategoriesScreen(navController: NavController, categories: List<Aud
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Categorii: $categoryName") },
+                title = { Text(stringResource(R.string.categories_title, categoryName)) },
                 navigationIcon = {
                     IconButton(onClick = {
                         Log.d("AudiobookCategoriesScreen", "Back button clicked")
@@ -55,7 +56,7 @@ fun AudiobookCategoriesScreen(navController: NavController, categories: List<Aud
                     }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi",
+                            contentDescription = stringResource(R.string.back),
                             tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
@@ -98,7 +99,7 @@ fun AudiobookCategoriesScreen(navController: NavController, categories: List<Aud
                             .padding(16.dp)
                             .clickable(
                                 enabled = true,
-                                onClickLabel = "Navighează la ${category.name}",
+                                onClickLabel = stringResource(R.string.navigate_to_category, category.name),
                                 onClick = {
                                     val encodedCategoryName = URLEncoder.encode(category.name, StandardCharsets.UTF_8.toString())
                                     navController.navigate("audiobook_testaments/${category.name}?categoryName=$encodedCategoryName")
@@ -108,7 +109,7 @@ fun AudiobookCategoriesScreen(navController: NavController, categories: List<Aud
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.LibraryBooks,
-                            contentDescription = "Icoană Categorie",
+                            contentDescription = stringResource(R.string.category_icon_desc),
                             modifier = Modifier.size(40.dp),
                             tint = MaterialTheme.colorScheme.primary
                         )
@@ -123,7 +124,7 @@ fun AudiobookCategoriesScreen(navController: NavController, categories: List<Aud
                         if (isHovered) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                contentDescription = "Navighează",
+                                contentDescription = stringResource(R.string.navigate),
                                 tint = MaterialTheme.colorScheme.secondary
                             )
                         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookChaptersScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookChaptersScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
 import androidx.work.WorkInfo
 import md.ortodox.ortodoxmd.data.model.audiobook.AudiobookEntity
 
@@ -52,9 +53,9 @@ fun AudiobookChaptersScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(book?.name ?: "Încărcare...", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                title = { Text(book?.name ?: stringResource(R.string.loading), maxLines = 1, overflow = TextOverflow.Ellipsis) },
                 navigationIcon = {
-                    IconButton(onClick = onNavigateBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Înapoi") }
+                    IconButton(onClick = onNavigateBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back)) }
                 }
             )
         },
@@ -67,20 +68,20 @@ fun AudiobookChaptersScreen(
                 when {
                     isDownloading -> ExtendedFloatingActionButton(
                         onClick = { viewModel.cancelAllDownloads() },
-                        icon = { Icon(Icons.Default.Cancel, "Anulează") },
-                        text = { Text("Anulează") },
+                        icon = { Icon(Icons.Default.Cancel, stringResource(R.string.cancel)) },
+                        text = { Text(stringResource(R.string.cancel)) },
                         containerColor = MaterialTheme.colorScheme.errorContainer
                     )
                     hasDeletableChapters -> ExtendedFloatingActionButton(
                         onClick = { book?.chapters?.let { viewModel.deleteAllDownloadedChapters(it) } },
-                        icon = { Icon(Icons.Default.Delete, "Șterge") },
-                        text = { Text("Șterge Descărcările") },
+                        icon = { Icon(Icons.Default.Delete, stringResource(R.string.delete)) },
+                        text = { Text(stringResource(R.string.delete_downloads)) },
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer
                     )
                     hasDownloadableChapters -> ExtendedFloatingActionButton(
                         onClick = { book?.chapters?.let { viewModel.downloadAllChapters(it) } },
-                        icon = { Icon(Icons.Default.Download, "Descarcă") },
-                        text = { Text("Descarcă") }
+                        icon = { Icon(Icons.Default.Download, stringResource(R.string.download)) },
+                        text = { Text(stringResource(R.string.download)) }
                     )
                 }
             }
@@ -109,7 +110,7 @@ fun AudiobookChaptersScreen(
                 }
             }
             else -> {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { Text("Cartea nu a fost găsită.") }
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { Text(stringResource(R.string.book_not_found)) }
             }
         }
     }
@@ -139,7 +140,7 @@ private fun ChapterItem(
         ) {
             Icon(
                 imageVector = Icons.Default.Headset,
-                contentDescription = "Icoană Capitol",
+                contentDescription = stringResource(R.string.chapter_icon_desc),
                 modifier = Modifier.size(40.dp),
                 tint = MaterialTheme.colorScheme.primary
             )
@@ -161,14 +162,14 @@ private fun ChapterItem(
                     isDownloaded -> Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
-                            contentDescription = "Descărcat",
+                            contentDescription = stringResource(R.string.downloaded),
                             tint = MaterialTheme.colorScheme.primary
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         IconButton(onClick = onDelete) {
                             Icon(
                                 Icons.Default.Delete,
-                                contentDescription = "Șterge",
+                                contentDescription = stringResource(R.string.delete),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                             )
                         }
@@ -185,16 +186,16 @@ private fun ChapterItem(
                     // --> AICI ESTE LOGICA PENTRU STAREA "ÎN AȘTEPTARE" <--
                     downloadState == WorkInfo.State.ENQUEUED -> Icon(
                         imageVector = Icons.Default.HourglassTop,
-                        contentDescription = "În așteptare",
+                        contentDescription = stringResource(R.string.waiting),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     downloadState == WorkInfo.State.FAILED || downloadState == WorkInfo.State.CANCELLED ->
                         IconButton(onClick = onDownload) {
-                            Icon(Icons.Default.Refresh, "Reîncearcă", tint = MaterialTheme.colorScheme.error)
+                            Icon(Icons.Default.Refresh, stringResource(R.string.retry), tint = MaterialTheme.colorScheme.error)
                         }
                     else ->
                         IconButton(onClick = onDownload) {
-                            Icon(Icons.Default.Download, "Descarcă", tint = MaterialTheme.colorScheme.secondary)
+                            Icon(Icons.Default.Download, stringResource(R.string.download), tint = MaterialTheme.colorScheme.secondary)
                         }
                 }
             }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookPlayerScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
@@ -60,7 +61,7 @@ fun AudiobookPlayerScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(uiState.audiobook?.title ?: "Se încarcă...") },
+                title = { Text(uiState.audiobook?.title ?: stringResource(R.string.loading)) },
                 navigationIcon = {
                     IconButton(onClick = {
                         Log.d("AudiobookPlayerScreen", "Back button clicked")
@@ -68,7 +69,7 @@ fun AudiobookPlayerScreen(
                     }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi",
+                            contentDescription = stringResource(R.string.back),
                             tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
@@ -143,7 +144,7 @@ private fun PlayerHeader(title: String, author: String) {
         Spacer(Modifier.height(32.dp))
         Icon(
             imageVector = Icons.AutoMirrored.Filled.MenuBook,
-            contentDescription = "Coperta Cărții",
+            contentDescription = stringResource(R.string.book_cover_desc),
             modifier = Modifier
                 .fillMaxWidth(0.6f)
                 .aspectRatio(1f),
@@ -204,10 +205,10 @@ private fun PlayerControls(
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = onPrevious, enabled = controlsEnabled) {
-                Icon(Icons.Default.SkipPrevious, "Previous", modifier = Modifier.size(32.dp))
+                Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous_track), modifier = Modifier.size(32.dp))
             }
             IconButton(onClick = onRewind, enabled = controlsEnabled) {
-                Icon(Icons.Default.Replay10, "Înapoi 10s", modifier = Modifier.size(32.dp))
+                Icon(Icons.Default.Replay10, stringResource(R.string.rewind_10s), modifier = Modifier.size(32.dp))
             }
             FilledIconButton(
                 onClick = onPlayPauseToggle,
@@ -219,16 +220,16 @@ private fun PlayerControls(
             ) {
                 Icon(
                     imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = "Play/Pauză",
+                    contentDescription = stringResource(R.string.play_pause),
                     modifier = Modifier.size(40.dp),
                     tint = MaterialTheme.colorScheme.onPrimary
                 )
             }
             IconButton(onClick = onForward, enabled = controlsEnabled) {
-                Icon(Icons.Default.Forward30, "Înainte 30s", modifier = Modifier.size(32.dp))
+                Icon(Icons.Default.Forward30, stringResource(R.string.forward_30s), modifier = Modifier.size(32.dp))
             }
             IconButton(onClick = onNext, enabled = controlsEnabled) {
-                Icon(Icons.Default.SkipNext, "Next", modifier = Modifier.size(32.dp))
+                Icon(Icons.Default.SkipNext, stringResource(R.string.next_track), modifier = Modifier.size(32.dp))
             }
         }
         Spacer(Modifier.height(32.dp))

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookTestamentScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookTestamentScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import java.net.URLEncoder
@@ -39,7 +40,7 @@ fun AudiobookTestamentsScreen(navController: NavController, testaments: List<Str
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Testamente: ${categoryName.ifEmpty { "Toate" }}") },
+                title = { Text(stringResource(R.string.testaments_title, categoryName.ifEmpty { stringResource(R.string.all) })) },
                 navigationIcon = {
                     IconButton(onClick = {
                         Log.d("AudiobookTestamentsScreen", "Back button clicked")
@@ -47,7 +48,7 @@ fun AudiobookTestamentsScreen(navController: NavController, testaments: List<Str
                     }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi",
+                            contentDescription = stringResource(R.string.back),
                             tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
@@ -85,7 +86,7 @@ fun AudiobookTestamentsScreen(navController: NavController, testaments: List<Str
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.LibraryBooks,
-                            contentDescription = "Icoană Testament",
+                            contentDescription = stringResource(R.string.testament_icon_desc),
                             modifier = Modifier.size(40.dp),
                             tint = MaterialTheme.colorScheme.primary
                         )
@@ -99,7 +100,7 @@ fun AudiobookTestamentsScreen(navController: NavController, testaments: List<Str
                         )
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = "Navighează",
+                            contentDescription = stringResource(R.string.navigate),
                             tint = MaterialTheme.colorScheme.secondary
                         )
                     }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleDownloadScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleDownloadScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
@@ -32,19 +33,19 @@ fun BibleDownloadScreen(
     ) {
         Icon(
             imageVector = Icons.Default.CloudDownload,
-            contentDescription = "Descarcă Biblia",
+            contentDescription = stringResource(R.string.download_bible_icon_desc),
             modifier = Modifier.size(64.dp),
             tint = MaterialTheme.colorScheme.primary
         )
         Spacer(Modifier.height(16.dp))
         Text(
-            text = "Descărcați Sfânta Scriptură",
+            text = stringResource(R.string.download_bible_title),
             style = MaterialTheme.typography.headlineSmall,
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "Pentru a accesa funcționalitatea completă, este necesară descărcarea textului integral al Bibliei (aprox. 10MB).",
+            text = stringResource(R.string.download_bible_message),
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center
         )
@@ -53,7 +54,7 @@ fun BibleDownloadScreen(
         when (val state = downloadState) {
             is DownloadState.Idle -> {
                 Button(onClick = { viewModel.startDownload() }) {
-                    Text("Pornește Descărcarea")
+                    Text(stringResource(R.string.start_download))
                 }
             }
             is DownloadState.Downloading -> {
@@ -64,20 +65,20 @@ fun BibleDownloadScreen(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text(text = "Descărcare... ${(animatedProgress * 100).toInt()}%")
+                    Text(text = stringResource(R.string.downloading_progress, (animatedProgress * 100).toInt()))
                 }
             }
             is DownloadState.Error -> {
                 Text(state.message, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
                 Spacer(Modifier.height(16.dp))
                 Button(onClick = { viewModel.startDownload() }) {
-                    Text("Reîncearcă")
+                    Text(stringResource(R.string.retry))
                 }
             }
             is DownloadState.Finished -> {
                 Icon(
                     imageVector = Icons.Default.CheckCircle,
-                    contentDescription = "Finalizat",
+                    contentDescription = stringResource(R.string.download_finished_icon_desc),
                     tint = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.size(48.dp)
                 )
@@ -85,7 +86,7 @@ fun BibleDownloadScreen(
                 Text(state.message, fontWeight = FontWeight.Bold)
                 Spacer(Modifier.height(16.dp))
                 Button(onClick = onDownloadComplete) {
-                    Text("Accesează Biblia")
+                    Text(stringResource(R.string.access_bible))
                 }
             }
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleHomeScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleHomeScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.annotation.StringRes
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -26,10 +28,10 @@ import androidx.navigation.navArgument
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
-private enum class BibleTab(val title: String, val icon: ImageVector, val route: String) {
-    BROWSE("Răsfoire", Icons.AutoMirrored.Filled.MenuBook, "bible_browse"),
-    SEARCH("Căutare", Icons.Default.Search, "bible_search"),
-    BOOKMARKS("Semne de Carte", Icons.Default.Bookmark, "bible_bookmarks")
+private enum class BibleTab(@StringRes val titleRes: Int, val icon: ImageVector, val route: String) {
+    BROWSE(R.string.tab_browse, Icons.AutoMirrored.Filled.MenuBook, "bible_browse"),
+    SEARCH(R.string.tab_search, Icons.Default.Search, "bible_search"),
+    BOOKMARKS(R.string.tab_bookmarks, Icons.Default.Bookmark, "bible_bookmarks")
 }
 
 @Composable
@@ -99,8 +101,8 @@ private fun BibleInterfaceWithTabs() {
                             restoreState = true
                         }
                     },
-                    text = { Text(tab.title) },
-                    icon = { Icon(tab.icon, contentDescription = tab.title) }
+                    text = { Text(stringResource(tab.titleRes)) },
+                    icon = { Icon(tab.icon, contentDescription = stringResource(tab.titleRes)) }
                 )
             }
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BookmarksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BookmarksScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -25,7 +26,7 @@ fun BookmarksScreen(
 
     if (bookmarks.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Nu aveți niciun semn de carte salvat.", modifier = Modifier.padding(16.dp))
+            Text(stringResource(R.string.no_bookmarks), modifier = Modifier.padding(16.dp))
         }
     } else {
         LazyColumn(contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BooksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BooksScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -34,9 +35,9 @@ fun BooksScreen(
 
     val uiState by viewModel.uiState.collectAsState()
     val title = when (testamentId) {
-        1L -> "Vechiul Testament"
-        2L -> "Noul Testament"
-        else -> "Cărți"
+        1L -> stringResource(R.string.old_testament)
+        2L -> stringResource(R.string.new_testament)
+        else -> stringResource(R.string.books)
     }
 
     Scaffold(
@@ -46,7 +47,7 @@ fun BooksScreen(
                 title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Înapoi la Testamente")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back_to_testaments))
                     }
                 }
             )

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/ChapterScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/ChapterScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -45,7 +46,7 @@ fun ChaptersScreen(
                 title = { Text(bookName, maxLines = 1, overflow = TextOverflow.Ellipsis) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Înapoi")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
                     }
                 }
             )
@@ -94,17 +95,17 @@ private fun ChapterCardItem(chapter: BibleChapter, onClick: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.MenuBook,
-                contentDescription = "Capitol",
+                contentDescription = stringResource(R.string.chapter_icon_desc),
                 tint = MaterialTheme.colorScheme.primary
             )
             Text(
-                text = "Capitolul ${chapter.chapterNumber}",
+                text = stringResource(R.string.chapter_number, chapter.chapterNumber),
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.weight(1f)
             )
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = "Vezi versete",
+                contentDescription = stringResource(R.string.view_verses),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/GlobalSearchScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/GlobalSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -28,7 +29,10 @@ fun GlobalSearchScreen(
         modifier = modifier.fillMaxSize(),
         floatingActionButton = {
             FloatingActionButton(onClick = { showHelpDialog = true }) {
-                Icon(Icons.Default.HelpOutline, contentDescription = "Ajutor Căutare")
+                Icon(
+                    Icons.Default.HelpOutline,
+                    contentDescription = stringResource(R.string.search_help)
+                )
             }
         }
     ) { paddingValues ->
@@ -41,7 +45,7 @@ fun GlobalSearchScreen(
             OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
-                label = { Text("Ex: Matei 2:15 sau Iisus") },
+                label = { Text(stringResource(R.string.global_search_example)) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true
             )
@@ -50,14 +54,14 @@ fun GlobalSearchScreen(
                 onClick = { viewModel.search(query) },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Caută")
+                Text(stringResource(R.string.search))
             }
             Spacer(Modifier.height(16.dp))
 
             when (val state = uiState) {
                 is SearchUiState.Idle -> {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("Introduceți un text pentru a căuta în Biblie.")
+                        Text(stringResource(R.string.global_search_hint))
                     }
                 }
                 is SearchUiState.Loading -> {
@@ -89,38 +93,38 @@ fun GlobalSearchScreen(
     if (showHelpDialog) {
         AlertDialog(
             onDismissRequest = { showHelpDialog = false },
-            icon = { Icon(Icons.Default.HelpOutline, contentDescription = "Ajutor") },
-            title = { Text("Principii de Căutare") },
+            icon = { Icon(Icons.Default.HelpOutline, contentDescription = stringResource(R.string.help)) },
+            title = { Text(stringResource(R.string.search_principles_title)) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text("Puteți căuta în două moduri:", style = MaterialTheme.typography.bodyMedium)
+                    Text(stringResource(R.string.search_principles_intro), style = MaterialTheme.typography.bodyMedium)
 
-                    Text("1. După Referință", style = MaterialTheme.typography.titleSmall)
+                    Text(stringResource(R.string.search_by_reference_title), style = MaterialTheme.typography.titleSmall)
                     Text(
-                        text = "Introduceți numele cărții (sau o abreviere), urmat de capitol și, opțional, verset.",
+                        text = stringResource(R.string.search_by_reference_desc),
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Text(
-                        text = "Exemple: Ioan 3:16, 1 Cor 13, Facerea 1:1-5",
+                        text = stringResource(R.string.search_by_reference_examples),
                         style = MaterialTheme.typography.bodySmall
                     )
 
                     Spacer(Modifier.height(8.dp))
 
-                    Text("2. După Cuvânt", style = MaterialTheme.typography.titleSmall)
+                    Text(stringResource(R.string.search_by_word_title), style = MaterialTheme.typography.titleSmall)
                     Text(
-                        text = "Introduceți orice cuvânt sau expresie pentru a căuta în tot textul Bibliei.",
+                        text = stringResource(R.string.search_by_word_desc),
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Text(
-                        text = "Exemple: mântuire, păstorul cel bun",
+                        text = stringResource(R.string.search_by_word_examples),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
             },
             confirmButton = {
                 TextButton(onClick = { showHelpDialog = false }) {
-                    Text("Am înțeles")
+                    Text(stringResource(R.string.understood))
                 }
             }
         )

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/TestamentsScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/TestamentsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 
@@ -16,8 +17,8 @@ import androidx.navigation.NavHostController
 @Composable
 fun TestamentsScreen(navController: NavHostController, modifier: Modifier = Modifier) {
     val testaments = listOf(
-        "Vechiul Testament" to "1",
-        "Noul Testament" to "2"
+        stringResource(R.string.old_testament) to "1",
+        stringResource(R.string.new_testament) to "2"
     )
 
     LazyColumn(

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/VersesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/VersesScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -26,10 +27,10 @@ fun VersesScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("${uiState.bookName} ${uiState.chapterNumber}") },
+                title = { Text(stringResource(R.string.bible_chapter_format, uiState.bookName, uiState.chapterNumber)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Înapoi")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
                     }
                 }
             )
@@ -40,7 +41,7 @@ fun VersesScreen(
             OutlinedTextField(
                 value = uiState.searchQuery,
                 onValueChange = viewModel::onSearchQueryChanged,
-                label = { Text("Caută în acest capitol...") },
+                label = { Text(stringResource(R.string.search_in_chapter)) },
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
                 singleLine = true
             )
@@ -60,7 +61,7 @@ fun VersesScreen(
                 else -> {
                     if (uiState.filteredVerses.isEmpty()) {
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Text("Niciun rezultat găsit.")
+                            Text(stringResource(R.string.no_results_found))
                         }
                     } else {
                         LazyColumn(contentPadding = PaddingValues(16.dp)) {
@@ -105,7 +106,7 @@ fun VerseItemWithBookmark(
         IconButton(onClick = onToggleBookmark) {
             Icon(
                 imageVector = if (uiVerse.isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
-                contentDescription = "Salvează semn de carte",
+                contentDescription = stringResource(R.string.save_bookmark),
                 tint = if (uiVerse.isBookmarked) MaterialTheme.colorScheme.primary else LocalContentColor.current
             )
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/calendar/CalendarScreen.kt
@@ -20,12 +20,15 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import md.ortodox.ortodoxmd.data.model.CalendarData
 import md.ortodox.ortodoxmd.domain.model.HolidayRank
 import md.ortodox.ortodoxmd.domain.model.RedLetterDays
+import md.ortodox.ortodoxmd.R
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -34,7 +37,7 @@ import java.util.*
 fun CalendarScreen(modifier: Modifier = Modifier, viewModel: CalendarViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showDatePicker by remember { mutableStateOf(false) }
-    val monthFormatter = remember { SimpleDateFormat("LLLL yyyy", Locale("ro")) }
+    val monthFormatter = remember { SimpleDateFormat("LLLL yyyy", Locale.getDefault()) }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
         Row(
@@ -44,9 +47,9 @@ fun CalendarScreen(modifier: Modifier = Modifier, viewModel: CalendarViewModel =
             val monthYearTitle = monthFormatter.format(uiState.selectedDate.time).replaceFirstChar { it.uppercase() }
             Text(monthYearTitle, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
             Spacer(Modifier.weight(1f))
-            OutlinedButton(onClick = viewModel::goToToday) { Text("Azi") }
+            OutlinedButton(onClick = viewModel::goToToday) { Text(stringResource(R.string.today)) }
             Spacer(Modifier.width(8.dp))
-            Button(onClick = { showDatePicker = true }) { Text("Selectează") }
+            Button(onClick = { showDatePicker = true }) { Text(stringResource(R.string.select)) }
         }
 
         if (showDatePicker) {
@@ -57,15 +60,16 @@ fun CalendarScreen(modifier: Modifier = Modifier, viewModel: CalendarViewModel =
                     Button(onClick = {
                         datePickerState.selectedDateMillis?.let { viewModel.updateFromPicker(it) }
                         showDatePicker = false
-                    }) { Text("OK") }
+                    }) { Text(stringResource(R.string.ok)) }
                 },
-                dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("Anulează") } }
+                dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text(stringResource(R.string.cancel)) } }
             ) { DatePicker(state = datePickerState) }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceAround) {
-            listOf("L", "Ma", "Mi", "J", "V", "S", "D").forEach { day ->
+            val weekdays = stringArrayResource(R.array.weekdays_short)
+            weekdays.forEach { day ->
                 Text(day, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center, modifier = Modifier.weight(1f))
             }
         }
@@ -174,8 +178,8 @@ private fun DayDetails(data: CalendarData?) {
     val holidayRank = RedLetterDays.getHolidayInfo(data, calendar)
 
     val correctedFastingDescription = when (data.fastingDescriptionRo.lowercase(Locale.ROOT)) {
-        "harti" -> "Zi fără post"
-        "post" -> "Zi de post"
+        "harti" -> stringResource(R.string.fasting_none)
+        "post" -> stringResource(R.string.fasting_day)
         else -> data.fastingDescriptionRo
     }
 
@@ -197,10 +201,10 @@ private fun DayDetails(data: CalendarData?) {
 
             Divider()
 
-            Text("Post: $correctedFastingDescription", style = MaterialTheme.typography.bodyLarge)
+            Text(stringResource(R.string.fasting, correctedFastingDescription), style = MaterialTheme.typography.bodyLarge)
 
             if (data.saints.isNotEmpty()) {
-                Text("Sfinții zilei:", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                Text(stringResource(R.string.saints_of_day), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
                 Column {
                     data.saints.forEach { saint ->
                         Text("• ${saint.nameAndDescriptionRo}", style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/home/HomeScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/home/HomeScreen.kt
@@ -19,11 +19,13 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import md.ortodox.ortodoxmd.R
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -78,7 +80,7 @@ fun HomeScreen(
 @Composable
 private fun TodayCard(calendarData: md.ortodox.ortodoxmd.data.model.CalendarData?, onClick: () -> Unit) {
     val calendar = Calendar.getInstance()
-    val dateDisplayFormat = SimpleDateFormat("EEEE, d MMMM yyyy", Locale("ro")).format(calendar.time)
+    val dateDisplayFormat = SimpleDateFormat("EEEE, d MMMM yyyy", Locale.getDefault()).format(calendar.time)
     val title = dateDisplayFormat.replaceFirstChar { it.uppercase() }
 
     Card(
@@ -95,13 +97,13 @@ private fun TodayCard(calendarData: md.ortodox.ortodoxmd.data.model.CalendarData
             Divider()
             if (calendarData != null) {
                 val fastingInfo = when (calendarData.fastingDescriptionRo.lowercase(Locale.ROOT)) {
-                    "harti" -> "Zi fără post"
+                    "harti" -> stringResource(R.string.fasting_none)
                     else -> calendarData.fastingDescriptionRo
                 }
                 InfoRow(icon = Icons.Default.Restaurant, text = fastingInfo)
                 InfoRow(icon = Icons.Default.Person, text = calendarData.saints.firstOrNull()?.nameAndDescriptionRo ?: calendarData.summaryTitleRo)
             } else {
-                InfoRow(icon = Icons.Default.CloudOff, text = "Datele nu au putut fi încărcate.")
+                InfoRow(icon = Icons.Default.CloudOff, text = stringResource(R.string.data_not_loaded))
             }
         }
     }
@@ -167,14 +169,14 @@ private fun ResumeListeningCard(info: ResumePlaybackInfo, onClick: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.Default.PlayCircleFilled,
-                contentDescription = "Reluați Ascultarea",
+                contentDescription = stringResource(R.string.resume_listening),
                 modifier = Modifier.size(48.dp),
                 tint = MaterialTheme.colorScheme.onTertiaryContainer
             )
             Spacer(Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Reluați Ascultarea",
+                    text = stringResource(R.string.resume_listening),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onTertiaryContainer
                 )
@@ -191,7 +193,7 @@ private fun ResumeListeningCard(info: ResumePlaybackInfo, onClick: () -> Unit) {
                     String.format("%02d:%02d", minutes, seconds)
                 }
                 Text(
-                    text = "Rămas la: $formattedDuration",
+                    text = stringResource(R.string.remaining_at, formattedDuration),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
                 )
@@ -204,19 +206,19 @@ private fun ResumeListeningCard(info: ResumePlaybackInfo, onClick: () -> Unit) {
 private fun QuickNavGrid(navController: NavHostController) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
-            text = "Explorați Aplicația",
+            text = stringResource(R.string.explore_app),
             style = MaterialTheme.typography.titleLarge
         )
         // Primul rând de butoane
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             NavButton(
-                title = "Biblia",
+                title = stringResource(R.string.menu_bible),
                 icon = Icons.Default.Book,
                 onClick = { navController.navigate("bible_home") },
                 modifier = Modifier.weight(1f)
             )
             NavButton(
-                title = "Rugăciuni",
+                title = stringResource(R.string.menu_prayers),
                 icon = Icons.AutoMirrored.Filled.MenuBook,
                 onClick = { navController.navigate("prayer_categories") },
                 modifier = Modifier.weight(1f)
@@ -225,13 +227,13 @@ private fun QuickNavGrid(navController: NavHostController) {
         // Al doilea rând de butoane
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             NavButton(
-                title = "Vieți Sfinți",
+                title = stringResource(R.string.menu_saint_lives),
                 icon = Icons.Default.Person,
                 onClick = { navController.navigate("saint_lives") },
                 modifier = Modifier.weight(1f)
             )
             NavButton(
-                title = "Anuar",
+                title = stringResource(R.string.menu_anuar),
                 icon = Icons.Default.Today,
                 onClick = { navController.navigate("anuar") },
                 modifier = Modifier.weight(1f)

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconDetailScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconDetailScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import md.ortodox.ortodoxmd.data.network.NetworkModule
+import md.ortodox.ortodoxmd.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,7 +44,7 @@ fun IconDetailScreen(
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi",
+                            contentDescription = stringResource(R.string.back),
                             tint = Color.White
                         )
                     }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconsScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -74,7 +75,7 @@ private fun IconCardItem(icon: Icon, onClick: () -> Unit) {
             // **NOU: Pictograma decorativă din stânga**
             Icon(
                 imageVector = Icons.Default.AutoAwesome, // Poți schimba cu orice altă pictogramă (ex: Icons.Default.Person)
-                contentDescription = "Icoană Sfânt",
+                contentDescription = stringResource(R.string.saint_icon_desc),
                 tint = MaterialTheme.colorScheme.primary
             )
 
@@ -90,7 +91,7 @@ private fun IconCardItem(icon: Icon, onClick: () -> Unit) {
             // Pictograma de navigare din dreapta
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = "Vezi detalii",
+                contentDescription = stringResource(R.string.view_details),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryDetailScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryDetailScreen.kt
@@ -20,9 +20,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import md.ortodox.ortodoxmd.R
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -42,7 +44,7 @@ fun MonasteryDetailScreen(
                 title = { Text(monastery?.nameRo ?: "", maxLines = 1, overflow = TextOverflow.Ellipsis) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Înapoi")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
                     }
                 }
             )
@@ -94,7 +96,7 @@ fun MonasteryDetailScreen(
                             if (mapIntent.resolveActivity(context.packageManager) != null) {
                                 context.startActivity(mapIntent)
                             } else {
-                                Toast.makeText(context, "Nu s-a găsit nicio aplicație de hărți.", Toast.LENGTH_LONG).show()
+                                Toast.makeText(context, stringResource(R.string.no_maps_app_found), Toast.LENGTH_LONG).show()
                             }
                         },
                     elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -109,11 +111,11 @@ fun MonasteryDetailScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Navigation,
-                            contentDescription = "Navighează",
+                            contentDescription = stringResource(R.string.navigate),
                             tint = MaterialTheme.colorScheme.onSecondaryContainer
                         )
                         Text(
-                            text = "Navighează pe hartă",
+                            text = stringResource(R.string.navigate_on_map),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.weight(1f)

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryListScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryListScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import md.ortodox.ortodoxmd.data.model.Monastery
@@ -63,7 +64,7 @@ private fun MonasteryCardItem(monastery: Monastery, onClick: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.Default.Church,
-                contentDescription = "Mănăstire",
+                contentDescription = stringResource(R.string.monastery_icon_desc),
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(32.dp)
             )
@@ -76,7 +77,7 @@ private fun MonasteryCardItem(monastery: Monastery, onClick: () -> Unit) {
             )
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = "Vezi detalii",
+                contentDescription = stringResource(R.string.view_details),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerCategoriesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerCategoriesScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import md.ortodox.ortodoxmd.prayerCategories
+import md.ortodox.ortodoxmd.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,13 +29,13 @@ fun PrayerCategoriesScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Categorii de Rugăciuni") },
+                title = { Text(stringResource(R.string.prayer_categories_title)) },
                 navigationIcon = {
                     // Buton pentru a te întoarce la ecranul anterior (ex: Home Screen)
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Înapoi"
+                            contentDescription = stringResource(R.string.back)
                         )
                     }
                 }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerScreen.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import md.ortodox.ortodoxmd.data.model.Prayer
+import md.ortodox.ortodoxmd.R
 
 @Composable
 fun PrayerScreen(category: String, modifier: Modifier = Modifier) {
@@ -37,14 +39,14 @@ fun PrayerScreen(category: String, modifier: Modifier = Modifier) {
             }
             is PrayerUiState.Empty -> {
                 Text(
-                    text = "Nu au fost găsite rugăciuni în această categorie.",
+                    text = stringResource(R.string.no_prayers_found),
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.align(Alignment.Center)
                 )
             }
             is PrayerUiState.Error -> {
                 Text(
-                    text = "A apărut o eroare: ${state.message}",
+                    text = stringResource(R.string.error_occurred, state.message),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.align(Alignment.Center).padding(16.dp)
@@ -107,11 +109,11 @@ fun PrayerItem(prayer: Prayer, level: Int) {
                     modifier = Modifier.weight(1f)
                 )
                 if (isClickable) {
-                    Icon(
-                        imageVector = Icons.Default.ExpandMore,
-                        contentDescription = "Expand",
-                        modifier = Modifier.rotate(rotationAngle)
-                    )
+                        Icon(
+                            imageVector = Icons.Default.ExpandMore,
+                            contentDescription = stringResource(R.string.expand),
+                            modifier = Modifier.rotate(rotationAngle)
+                        )
                 }
             }
 

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/radio/RadioScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/radio/RadioScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
@@ -99,9 +100,9 @@ fun PlayerControls(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = when {
-                        isBuffering -> "CONECTARE..."
-                        isPlaying -> "ACUM RULEAZĂ"
-                        else -> "OPRIT"
+                        isBuffering -> stringResource(R.string.connecting)
+                        isPlaying -> stringResource(R.string.now_playing)
+                        else -> stringResource(R.string.stopped)
                     },
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.primary
@@ -127,7 +128,7 @@ fun PlayerControls(
                     ) {
                         Icon(
                             imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                            contentDescription = "Play/Pause",
+                            contentDescription = stringResource(R.string.play_pause),
                             modifier = Modifier.fillMaxSize()
                         )
                     }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/sacrament/SacramentScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/sacrament/SacramentScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import md.ortodox.ortodoxmd.data.model.Sacrament
 
@@ -73,7 +74,7 @@ private fun SacramentCard(sacrament: Sacrament) {
             ) {
                 Icon(
                     imageVector = Icons.Default.Bookmark,
-                    contentDescription = "Sacrament",
+                    contentDescription = stringResource(R.string.sacrament_icon_desc),
                     tint = MaterialTheme.colorScheme.secondary
                 )
                 Text(
@@ -83,7 +84,7 @@ private fun SacramentCard(sacrament: Sacrament) {
                 )
                 Icon(
                     imageVector = Icons.Default.ExpandMore,
-                    contentDescription = "Extinde",
+                    contentDescription = stringResource(R.string.expand),
                     modifier = Modifier.rotate(rotationAngle)
                 )
             }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/saints/SaintLivesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/saints/SaintLivesScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import md.ortodox.ortodoxmd.data.model.SaintLife
@@ -60,7 +61,7 @@ private fun SaintLifeCardItem(saintLife: SaintLife, onClick: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.Default.AutoAwesome,
-                contentDescription = "Icoană Sfânt",
+                contentDescription = stringResource(R.string.saint_icon_desc),
                 tint = MaterialTheme.colorScheme.primary
             )
             Text(
@@ -72,7 +73,7 @@ private fun SaintLifeCardItem(saintLife: SaintLife, onClick: () -> Unit) {
             )
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = "Vezi detalii",
+                contentDescription = stringResource(R.string.view_details),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/settings/LanguageSettingsScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/settings/LanguageSettingsScreen.kt
@@ -1,0 +1,67 @@
+package md.ortodox.ortodoxmd.ui.settings
+
+import android.app.Activity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import md.ortodox.ortodoxmd.R
+import md.ortodox.ortodoxmd.util.LocaleHelper
+
+@Composable
+fun LanguageSettingsScreen(viewModel: LanguageViewModel = hiltViewModel()) {
+    val current by viewModel.language.collectAsState()
+    val context = LocalContext.current
+    val activity = context as Activity
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = stringResource(R.string.select_language), style = MaterialTheme.typography.titleLarge)
+        LanguageOption("ro", stringResource(R.string.language_romanian), current == "ro") {
+            viewModel.setLanguage("ro")
+            LocaleHelper.applyLanguage(context, "ro")
+            activity.recreate()
+        }
+        LanguageOption("ru", stringResource(R.string.language_russian), current == "ru") {
+            viewModel.setLanguage("ru")
+            LocaleHelper.applyLanguage(context, "ru")
+            activity.recreate()
+        }
+        LanguageOption("en", stringResource(R.string.language_english), current == "en") {
+            viewModel.setLanguage("en")
+            LocaleHelper.applyLanguage(context, "en")
+            activity.recreate()
+        }
+    }
+}
+
+@Composable
+private fun LanguageOption(code: String, label: String, selected: Boolean, onSelect: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        RadioButton(selected = selected, onClick = onSelect)
+        Text(
+            text = label,
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .clickable { onSelect() }
+        )
+    }
+}

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/settings/LanguageViewModel.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/settings/LanguageViewModel.kt
@@ -1,0 +1,21 @@
+package md.ortodox.ortodoxmd.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import md.ortodox.ortodoxmd.data.preferences.LanguagePreferences
+
+@HiltViewModel
+class LanguageViewModel @Inject constructor(
+    private val prefs: LanguagePreferences
+) : ViewModel() {
+    val language = prefs.language.stateIn(viewModelScope, SharingStarted.Eagerly, "ro")
+
+    fun setLanguage(code: String) {
+        viewModelScope.launch { prefs.setLanguage(code) }
+    }
+}

--- a/app/src/main/java/md/ortodox/ortodoxmd/util/LocaleHelper.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/util/LocaleHelper.kt
@@ -1,0 +1,15 @@
+package md.ortodox.ortodoxmd.util
+
+import android.content.Context
+import android.content.res.Configuration
+import java.util.Locale
+
+object LocaleHelper {
+    fun applyLanguage(context: Context, language: String) {
+        val locale = Locale(language)
+        Locale.setDefault(locale)
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+        context.resources.updateConfiguration(config, context.resources.displayMetrics)
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,177 @@
+<resources>
+    <string name="app_name">Orthodox Moldova</string>
+    <string name="playback_channel_name">Audio Playback</string>
+    <string name="playback_channel_description">Notification for controlling audio playback</string>
+
+    <!-- Menu items -->
+    <string name="menu_home">Home</string>
+    <string name="menu_main">Main</string>
+    <string name="menu_calendar">Calendar</string>
+    <string name="menu_anuar">Church Yearbook</string>
+    <string name="menu_bible">Holy Scripture</string>
+    <string name="menu_spiritual_resources">Spiritual Resources</string>
+    <string name="menu_prayers">Prayers</string>
+    <string name="menu_saint_lives">Lives of Saints</string>
+    <string name="menu_icons">Icons</string>
+    <string name="menu_monasteries">Monasteries</string>
+    <string name="menu_sacraments">Sacraments and Services</string>
+    <string name="menu_apologetics">Apologetics</string>
+    <string name="menu_media">Media</string>
+    <string name="menu_radio">Radio</string>
+    <string name="menu_audiobooks">Audiobooks</string>
+    <string name="menu_language">Language</string>
+
+    <!-- Prayer subcategories -->
+    <string name="prayer_morning">Morning Prayers</string>
+    <string name="prayer_evening">Evening Prayers</string>
+    <string name="prayer_illness">Prayers for Illness</string>
+    <string name="prayer_general">General Prayers</string>
+
+    <!-- Language selection -->
+    <string name="select_language">Select Language</string>
+    <string name="language_romanian">Romanian</string>
+    <string name="language_russian">Russian</string>
+    <string name="language_english">English</string>
+
+    <!-- Misc -->
+    <string name="banner_description">Orthodox Moldova Banner</string>
+    <string name="expand">Expand</string>
+
+    <!-- Notifications -->
+    <string name="notification_daily_calendar_channel_name">Daily Calendar Notifications</string>
+    <string name="notification_daily_calendar_channel_description">Shows daily information from the Orthodox calendar.</string>
+
+    <!-- Common actions -->
+    <string name="back">Back</string>
+    <string name="today">Today</string>
+    <string name="select">Select</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
+
+    <!-- Calendar -->
+    <string-array name="weekdays_short">
+        <item>M</item>
+        <item>Tu</item>
+        <item>W</item>
+        <item>Th</item>
+        <item>F</item>
+        <item>Sa</item>
+        <item>Su</item>
+    </string-array>
+    <string name="fasting_none">No fasting day</string>
+    <string name="fasting_day">Fasting day</string>
+    <string name="fasting">Fasting: %1$s</string>
+    <string name="saints_of_day">Saints of the day:</string>
+
+    <!-- Prayer -->
+    <string name="prayer_categories_title">Prayer Categories</string>
+    <string name="no_prayers_found">No prayers found in this category.</string>
+    <string name="error_occurred">An error occurred: %1$s</string>
+
+    <!-- Monastery -->
+    <string name="no_maps_app_found">No maps application found.</string>
+    <string name="navigate">Navigate</string>
+    <string name="navigate_on_map">Navigate on map</string>
+    <string name="data_not_loaded">Data could not be loaded.</string>
+
+    <!-- Apologetics -->
+    <string name="apologetics_search_placeholder">Search a topic...</string>
+    <string name="search">Search</string>
+    <string name="question">Question</string>
+
+    <!-- Global search -->
+    <string name="search_help">Search Help</string>
+    <string name="global_search_example">Ex: Matthew 2:15 or Jesus</string>
+    <string name="global_search_hint">Enter text to search the Bible.</string>
+    <string name="search_principles_title">Search Principles</string>
+    <string name="search_principles_intro">You can search in two ways:</string>
+    <string name="search_by_reference_title">1. By Reference</string>
+    <string name="search_by_reference_desc">Enter the book name (or abbreviation), followed by chapter and optionally verse.</string>
+    <string name="search_by_reference_examples">Examples: John 3:16, 1 Cor 13, Genesis 1:1-5</string>
+    <string name="search_by_word_title">2. By Word</string>
+    <string name="search_by_word_desc">Enter any word or phrase to search the entire Bible text.</string>
+    <string name="search_by_word_examples">Examples: salvation, the good shepherd</string>
+    <string name="understood">Got it</string>
+    <string name="help">Help</string>
+
+    <!-- Bible download -->
+    <string name="download_bible_icon_desc">Download Bible</string>
+    <string name="download_bible_title">Download the Holy Scripture</string>
+    <string name="download_bible_message">To access full functionality, you need to download the complete text of the Bible (approx. 10MB).</string>
+    <string name="start_download">Start Download</string>
+    <string name="downloading_progress">Downloading... %1$d%%</string>
+    <string name="retry">Retry</string>
+    <string name="download_finished_icon_desc">Finished</string>
+    <string name="access_bible">Access Bible</string>
+
+    <!-- Bible reading -->
+    <string name="bible_chapter_format">%1$s %2$d</string>
+    <string name="search_in_chapter">Search in this chapter...</string>
+    <string name="no_results_found">No results found.</string>
+    <string name="save_bookmark">Save bookmark</string>
+    <string name="no_bookmarks">You have no bookmarks saved.</string>
+    <string name="tab_browse">Browse</string>
+    <string name="tab_search">Search</string>
+    <string name="tab_bookmarks">Bookmarks</string>
+    <string name="old_testament">Old Testament</string>
+    <string name="new_testament">New Testament</string>
+    <string name="books">Books</string>
+    <string name="back_to_testaments">Back to Testaments</string>
+    <string name="chapter_icon_desc">Chapter</string>
+    <string name="chapter_number">Chapter %1$d</string>
+    <string name="view_verses">View verses</string>
+
+    <!-- Anuar -->
+    <string name="no_services">No services available for this day.</string>
+    <string name="previous_day">Previous day</string>
+    <string name="next_day">Next day</string>
+    <string name="vespers">Vespers</string>
+    <string name="matins">Matins</string>
+    <string name="divine_liturgy">Divine Liturgy</string>
+    <string name="no_service_details">No details for this service.</string>
+
+    <!-- Audiobook -->
+    <string name="categories_title">Categories: %1$s</string>
+    <string name="navigate_to_category">Navigate to %1$s</string>
+    <string name="category_icon_desc">Category icon</string>
+    <string name="testaments_title">Testaments: %1$s</string>
+    <string name="all">All</string>
+    <string name="testament_icon_desc">Testament icon</string>
+    <string name="loading">Loading...</string>
+    <string name="delete_downloads">Delete Downloads</string>
+    <string name="delete">Delete</string>
+    <string name="download">Download</string>
+    <string name="downloaded">Downloaded</string>
+    <string name="waiting">Waiting</string>
+    <string name="book_not_found">Book not found.</string>
+
+    <!-- Radio -->
+    <string name="connecting">CONNECTING...</string>
+    <string name="now_playing">NOW PLAYING</string>
+    <string name="stopped">STOPPED</string>
+    <string name="play_pause">Play/Pause</string>
+
+    <!-- Audiobook Books -->
+    <string name="navigate_to_book">Navigate to %1$s</string>
+    <string name="book_icon_desc">Book icon</string>
+    <string name="book_cover_desc">Book Cover</string>
+    <string name="previous_track">Previous</string>
+    <string name="rewind_10s">Rewind 10s</string>
+    <string name="forward_30s">Forward 30s</string>
+    <string name="next_track">Next</string>
+
+    <!-- Sacrament -->
+    <string name="sacrament_icon_desc">Sacrament</string>
+
+    <!-- Monastery -->
+    <string name="monastery_icon_desc">Monastery</string>
+    <string name="view_details">See details</string>
+
+    <!-- Saints -->
+    <string name="saint_icon_desc">Saint icon</string>
+
+    <!-- Home -->
+    <string name="resume_listening">Resume Listening</string>
+    <string name="remaining_at">Remaining at: %1$s</string>
+    <string name="explore_app">Explore the App</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,177 @@
+<resources>
+    <string name="app_name">Православная Молдова</string>
+    <string name="playback_channel_name">Аудиовоспроизведение</string>
+    <string name="playback_channel_description">Уведомление для управления аудиовоспроизведением</string>
+
+    <!-- Menu items -->
+    <string name="menu_home">Главная</string>
+    <string name="menu_main">Основное</string>
+    <string name="menu_calendar">Календарь</string>
+    <string name="menu_anuar">Церковный ежегодник</string>
+    <string name="menu_bible">Святое Писание</string>
+    <string name="menu_spiritual_resources">Духовные ресурсы</string>
+    <string name="menu_prayers">Молитвы</string>
+    <string name="menu_saint_lives">Жития святых</string>
+    <string name="menu_icons">Иконы</string>
+    <string name="menu_monasteries">Монастыри</string>
+    <string name="menu_sacraments">Таинства и службы</string>
+    <string name="menu_apologetics">Апологетика</string>
+    <string name="menu_media">Медиа</string>
+    <string name="menu_radio">Радио</string>
+    <string name="menu_audiobooks">Аудиокниги</string>
+    <string name="menu_language">Язык</string>
+
+    <!-- Prayer subcategories -->
+    <string name="prayer_morning">Утренние молитвы</string>
+    <string name="prayer_evening">Вечерние молитвы</string>
+    <string name="prayer_illness">Молитвы при болезни</string>
+    <string name="prayer_general">Общие молитвы</string>
+
+    <!-- Language selection -->
+    <string name="select_language">Выберите язык</string>
+    <string name="language_romanian">Румынский</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_english">Английский</string>
+
+    <!-- Misc -->
+    <string name="banner_description">Баннер Православная Молдова</string>
+    <string name="expand">Развернуть</string>
+
+    <!-- Notifications -->
+    <string name="notification_daily_calendar_channel_name">Уведомления ежедневного календаря</string>
+    <string name="notification_daily_calendar_channel_description">Отображает ежедневную информацию из православного календаря.</string>
+
+    <!-- Common actions -->
+    <string name="back">Назад</string>
+    <string name="today">Сегодня</string>
+    <string name="select">Выбрать</string>
+    <string name="ok">ОК</string>
+    <string name="cancel">Отмена</string>
+
+    <!-- Calendar -->
+    <string-array name="weekdays_short">
+        <item>Пн</item>
+        <item>Вт</item>
+        <item>Ср</item>
+        <item>Чт</item>
+        <item>Пт</item>
+        <item>Сб</item>
+        <item>Вс</item>
+    </string-array>
+    <string name="fasting_none">День без поста</string>
+    <string name="fasting_day">День поста</string>
+    <string name="fasting">Пост: %1$s</string>
+    <string name="saints_of_day">Святые дня:</string>
+
+    <!-- Prayer -->
+    <string name="prayer_categories_title">Категории молитв</string>
+    <string name="no_prayers_found">В этой категории молитв не найдено.</string>
+    <string name="error_occurred">Произошла ошибка: %1$s</string>
+
+    <!-- Monastery -->
+    <string name="no_maps_app_found">Приложение карт не найдено.</string>
+    <string name="navigate">Навигация</string>
+    <string name="navigate_on_map">Навигация по карте</string>
+    <string name="data_not_loaded">Данные не удалось загрузить.</string>
+
+    <!-- Apologetics -->
+    <string name="apologetics_search_placeholder">Искать тему...</string>
+    <string name="search">Поиск</string>
+    <string name="question">Вопрос</string>
+
+    <!-- Global search -->
+    <string name="search_help">Помощь по поиску</string>
+    <string name="global_search_example">Пр.: Матф. 2:15 или Иисус</string>
+    <string name="global_search_hint">Введите текст, чтобы искать в Библии.</string>
+    <string name="search_principles_title">Принципы поиска</string>
+    <string name="search_principles_intro">Вы можете искать двумя способами:</string>
+    <string name="search_by_reference_title">1. По ссылке</string>
+    <string name="search_by_reference_desc">Введите название книги (или сокращение), затем главу и, при необходимости, стих.</string>
+    <string name="search_by_reference_examples">Примеры: Иоан. 3:16, 1 Кор 13, Быт. 1:1-5</string>
+    <string name="search_by_word_title">2. По слову</string>
+    <string name="search_by_word_desc">Введите любое слово или выражение для поиска по всему тексту Библии.</string>
+    <string name="search_by_word_examples">Примеры: спасение, добрый пастырь</string>
+    <string name="understood">Понятно</string>
+    <string name="help">Помощь</string>
+
+    <!-- Bible download -->
+    <string name="download_bible_icon_desc">Скачать Библию</string>
+    <string name="download_bible_title">Скачайте Святое Писание</string>
+    <string name="download_bible_message">Для доступа ко всем функциям необходимо скачать полный текст Библии (примерно 10 МБ).</string>
+    <string name="start_download">Начать загрузку</string>
+    <string name="downloading_progress">Загрузка... %1$d%%</string>
+    <string name="retry">Повторить</string>
+    <string name="download_finished_icon_desc">Завершено</string>
+    <string name="access_bible">Перейти к Библии</string>
+
+    <!-- Bible reading -->
+    <string name="bible_chapter_format">%1$s %2$d</string>
+    <string name="search_in_chapter">Искать в этой главе...</string>
+    <string name="no_results_found">Ничего не найдено.</string>
+    <string name="save_bookmark">Сохранить закладку</string>
+    <string name="no_bookmarks">У вас нет сохранённых закладок.</string>
+    <string name="tab_browse">Просмотр</string>
+    <string name="tab_search">Поиск</string>
+    <string name="tab_bookmarks">Закладки</string>
+    <string name="old_testament">Ветхий Завет</string>
+    <string name="new_testament">Новый Завет</string>
+    <string name="books">Книги</string>
+    <string name="back_to_testaments">Назад к Заветам</string>
+    <string name="chapter_icon_desc">Глава</string>
+    <string name="chapter_number">Глава %1$d</string>
+    <string name="view_verses">Посмотреть стихи</string>
+
+    <!-- Anuar -->
+    <string name="no_services">На этот день нет доступных богослужений.</string>
+    <string name="previous_day">Предыдущий день</string>
+    <string name="next_day">Следующий день</string>
+    <string name="vespers">Вечерня</string>
+    <string name="matins">Утреня</string>
+    <string name="divine_liturgy">Божественная литургия</string>
+    <string name="no_service_details">Нет деталей для этой службы.</string>
+
+    <!-- Audiobook -->
+    <string name="categories_title">Категории: %1$s</string>
+    <string name="navigate_to_category">Перейти к %1$s</string>
+    <string name="category_icon_desc">Значок категории</string>
+    <string name="testaments_title">Заветы: %1$s</string>
+    <string name="all">Все</string>
+    <string name="testament_icon_desc">Значок завета</string>
+    <string name="loading">Загрузка...</string>
+    <string name="delete_downloads">Удалить загрузки</string>
+    <string name="delete">Удалить</string>
+    <string name="download">Скачать</string>
+    <string name="downloaded">Загружено</string>
+    <string name="waiting">Ожидание</string>
+    <string name="book_not_found">Книга не найдена.</string>
+
+    <!-- Radio -->
+    <string name="connecting">ПОДКЛЮЧЕНИЕ...</string>
+    <string name="now_playing">СЕЙЧАС ВОСПРОИЗВОДИТСЯ</string>
+    <string name="stopped">ОСТАНОВЛЕНО</string>
+    <string name="play_pause">Воспроизвести/Пауза</string>
+
+    <!-- Audiobook Books -->
+    <string name="navigate_to_book">Перейти к %1$s</string>
+    <string name="book_icon_desc">Значок книги</string>
+    <string name="book_cover_desc">Обложка книги</string>
+    <string name="previous_track">Предыдущий</string>
+    <string name="rewind_10s">Назад 10с</string>
+    <string name="forward_30s">Вперёд 30с</string>
+    <string name="next_track">Следующий</string>
+
+    <!-- Sacrament -->
+    <string name="sacrament_icon_desc">Таинство</string>
+
+    <!-- Monastery -->
+    <string name="monastery_icon_desc">Монастырь</string>
+    <string name="view_details">Посмотреть детали</string>
+
+    <!-- Saints -->
+    <string name="saint_icon_desc">Значок святого</string>
+
+    <!-- Home -->
+    <string name="resume_listening">Возобновить прослушивание</string>
+    <string name="remaining_at">Осталось на: %1$s</string>
+    <string name="explore_app">Исследуйте приложение</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,176 @@
     <string name="app_name">Ortodox Moldova</string>
     <string name="playback_channel_name">Redare Audio</string>
     <string name="playback_channel_description">Notificare pentru controlul redării audio</string>
+
+    <!-- Menu items -->
+    <string name="menu_home">Acasă</string>
+    <string name="menu_main">Principal</string>
+    <string name="menu_calendar">Calendar</string>
+    <string name="menu_anuar">Anuar Bisericesc</string>
+    <string name="menu_bible">Sfânta Scriptură</string>
+    <string name="menu_spiritual_resources">Resurse Spirituale</string>
+    <string name="menu_prayers">Rugăciuni</string>
+    <string name="menu_saint_lives">Vieți Sfinți</string>
+    <string name="menu_icons">Icoane</string>
+    <string name="menu_monasteries">Mănăstiri</string>
+    <string name="menu_sacraments">Taine și Slujbe</string>
+    <string name="menu_apologetics">Apologetică</string>
+    <string name="menu_media">Media</string>
+    <string name="menu_radio">Radio</string>
+    <string name="menu_audiobooks">Cărți Audio</string>
+    <string name="menu_language">Limba</string>
+
+    <!-- Prayer subcategories -->
+    <string name="prayer_morning">Rugăciuni de Dimineață</string>
+    <string name="prayer_evening">Rugăciuni de Seară</string>
+    <string name="prayer_illness">Rugăciuni pentru Boală</string>
+    <string name="prayer_general">Rugăciuni Generale</string>
+
+    <!-- Language selection -->
+    <string name="select_language">Selectați limba</string>
+    <string name="language_romanian">Română</string>
+    <string name="language_russian">Rusă</string>
+    <string name="language_english">Engleză</string>
+
+    <!-- Misc -->
+    <string name="banner_description">Banner Ortodox Moldova</string>
+    <string name="expand">Extinde</string>
+
+    <!-- Notifications -->
+    <string name="notification_daily_calendar_channel_name">Notificări Calendar Zilnic</string>
+    <string name="notification_daily_calendar_channel_description">Afișează informațiile zilnice din calendarul ortodox.</string>
+
+    <!-- Common actions -->
+    <string name="back">Înapoi</string>
+    <string name="today">Azi</string>
+    <string name="select">Selectează</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Anulează</string>
+
+    <!-- Calendar -->
+    <string-array name="weekdays_short">
+        <item>L</item>
+        <item>Ma</item>
+        <item>Mi</item>
+        <item>J</item>
+        <item>V</item>
+        <item>S</item>
+        <item>D</item>
+    </string-array>
+    <string name="fasting_none">Zi fără post</string>
+    <string name="fasting_day">Zi de post</string>
+    <string name="fasting">Post: %1$s</string>
+    <string name="saints_of_day">Sfinții zilei:</string>
+
+    <!-- Prayer -->
+    <string name="prayer_categories_title">Categorii de Rugăciuni</string>
+    <string name="no_prayers_found">Nu au fost găsite rugăciuni în această categorie.</string>
+    <string name="error_occurred">A apărut o eroare: %1$s</string>
+
+    <!-- Monastery -->
+    <string name="no_maps_app_found">Nu s-a găsit nicio aplicație de hărți.</string>
+    <string name="navigate">Navighează</string>
+    <string name="navigate_on_map">Navighează pe hartă</string>
+    <string name="data_not_loaded">Datele nu au putut fi încărcate.</string>
+
+    <!-- Apologetics -->
+    <string name="apologetics_search_placeholder">Caută un subiect...</string>
+    <string name="search">Caută</string>
+    <string name="question">Întrebare</string>
+
+    <!-- Global search -->
+    <string name="search_help">Ajutor Căutare</string>
+    <string name="global_search_example">Ex: Matei 2:15 sau Iisus</string>
+    <string name="global_search_hint">Introduceți un text pentru a căuta în Biblie.</string>
+    <string name="search_principles_title">Principii de Căutare</string>
+    <string name="search_principles_intro">Puteți căuta în două moduri:</string>
+    <string name="search_by_reference_title">1. După Referință</string>
+    <string name="search_by_reference_desc">Introduceți numele cărții (sau o abreviere), urmat de capitol și, opțional, verset.</string>
+    <string name="search_by_reference_examples">Exemple: Ioan 3:16, 1 Cor 13, Facerea 1:1-5</string>
+    <string name="search_by_word_title">2. După Cuvânt</string>
+    <string name="search_by_word_desc">Introduceți orice cuvânt sau expresie pentru a căuta în tot textul Bibliei.</string>
+    <string name="search_by_word_examples">Exemple: mântuire, păstorul cel bun</string>
+    <string name="understood">Am înțeles</string>
+    <string name="help">Ajutor</string>
+
+    <!-- Bible download -->
+    <string name="download_bible_icon_desc">Descarcă Biblia</string>
+    <string name="download_bible_title">Descărcați Sfânta Scriptură</string>
+    <string name="download_bible_message">Pentru a accesa funcționalitatea completă, este necesară descărcarea textului integral al Bibliei (aprox. 10MB).</string>
+    <string name="start_download">Pornește Descărcarea</string>
+    <string name="downloading_progress">Descărcare... %1$d%%</string>
+    <string name="retry">Reîncearcă</string>
+    <string name="download_finished_icon_desc">Finalizat</string>
+    <string name="access_bible">Accesează Biblia</string>
+
+    <!-- Bible reading -->
+    <string name="bible_chapter_format">%1$s %2$d</string>
+    <string name="search_in_chapter">Caută în acest capitol...</string>
+    <string name="no_results_found">Niciun rezultat găsit.</string>
+    <string name="save_bookmark">Salvează semn de carte</string>
+    <string name="no_bookmarks">Nu aveți niciun semn de carte salvat.</string>
+    <string name="tab_browse">Răsfoire</string>
+    <string name="tab_search">Căutare</string>
+    <string name="tab_bookmarks">Semne de Carte</string>
+    <string name="old_testament">Vechiul Testament</string>
+    <string name="new_testament">Noul Testament</string>
+    <string name="books">Cărți</string>
+    <string name="back_to_testaments">Înapoi la Testamente</string>
+    <string name="chapter_icon_desc">Capitol</string>
+    <string name="chapter_number">Capitolul %1$d</string>
+    <string name="view_verses">Vezi versete</string>
+
+    <!-- Anuar -->
+    <string name="no_services">Pentru această zi nu sunt disponibile rânduieli.</string>
+    <string name="previous_day">Ziua precedentă</string>
+    <string name="next_day">Ziua următoare</string>
+    <string name="vespers">Vecernie</string>
+    <string name="matins">Utrenie</string>
+    <string name="divine_liturgy">Sfânta Liturghie</string>
+    <string name="no_service_details">Nu sunt detalii pentru această slujbă.</string>
+
+    <!-- Audiobook -->
+    <string name="categories_title">Categorii: %1$s</string>
+    <string name="navigate_to_category">Navighează la %1$s</string>
+    <string name="category_icon_desc">Icoană Categorie</string>
+    <string name="testaments_title">Testamente: %1$s</string>
+    <string name="all">Toate</string>
+    <string name="testament_icon_desc">Icoană Testament</string>
+    <string name="loading">Încărcare...</string>
+    <string name="delete_downloads">Șterge Descărcările</string>
+    <string name="delete">Șterge</string>
+    <string name="download">Descarcă</string>
+    <string name="downloaded">Descărcat</string>
+    <string name="waiting">În așteptare</string>
+    <string name="book_not_found">Cartea nu a fost găsită.</string>
+
+    <!-- Radio -->
+    <string name="connecting">Conectare...</string>
+    <string name="now_playing">Acum rulează</string>
+    <string name="stopped">Oprit</string>
+    <string name="play_pause">Redă/Pauză</string>
+
+    <!-- Audiobook Books -->
+    <string name="navigate_to_book">Navighează la %1$s</string>
+    <string name="book_icon_desc">Icoană Carte</string>
+    <string name="book_cover_desc">Coperta Cărții</string>
+    <string name="previous_track">Precedent</string>
+    <string name="rewind_10s">Înapoi 10s</string>
+    <string name="forward_30s">Înainte 30s</string>
+    <string name="next_track">Următor</string>
+
+    <!-- Sacrament -->
+    <string name="sacrament_icon_desc">Sacrament</string>
+
+    <!-- Monastery -->
+    <string name="monastery_icon_desc">Mănăstire</string>
+    <string name="view_details">Vezi detalii</string>
+
+    <!-- Saints -->
+    <string name="saint_icon_desc">Icoană Sfânt</string>
+
+    <!-- Home -->
+    <string name="resume_listening">Reluați Ascultarea</string>
+    <string name="remaining_at">Rămas la: %1$s</string>
+    <string name="explore_app">Explorați Aplicația</string>
 </resources>


### PR DESCRIPTION
## Summary
- externalize remaining hardcoded UI text across radio, audiobook, home, monastery, icon and other screens
- add Romanian, English and Russian translations for new UI strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895978cf308832494cf63b8f1659979