### PR TITLE
Fix resource imports and lifecycle after translation merge

### DIFF
--- a/app/src/main/java/md/ortodox/ortodoxmd/data/preferences/LanguagePreferences.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/data/preferences/LanguagePreferences.kt
@@ -22,7 +22,7 @@ class LanguagePreferences @Inject constructor(@ApplicationContext private val co
     }
 
     suspend fun setLanguage(lang: String) {
-        context.dataStore.edit { prefs: Preferences ->
+        context.dataStore.edit { prefs ->
             prefs[LANGUAGE] = lang
         }
     }

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/anuar/AnuarScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/anuar/AnuarScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.anuar
+import md.ortodox.ortodoxmd.R
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/apologetic/ApologeticScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/apologetic/ApologeticScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.apologetics
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookBooksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookBooksScreen.kt
@@ -1,6 +1,8 @@
 // AudiobookBooksScreen.kt (corectat)
 package md.ortodox.ortodoxmd.ui.audiobook
 
+import md.ortodox.ortodoxmd.R
+
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookCategoriesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookCategoriesScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.audiobook
+import md.ortodox.ortodoxmd.R
 
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookChaptersScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookChaptersScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.audiobook
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookPlayerScreen.kt
@@ -2,6 +2,8 @@
 
 package md.ortodox.ortodoxmd.ui.audiobook
 
+import md.ortodox.ortodoxmd.R
+
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookTestamentScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/audiobook/AudiobookTestamentScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.audiobook
+import md.ortodox.ortodoxmd.R
 
 import android.util.Log
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleDownloadScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleDownloadScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleHomeScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BibleHomeScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BookmarksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BookmarksScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BooksScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/BooksScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/ChapterScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/ChapterScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/GlobalSearchScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/GlobalSearchScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/TestamentsScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/TestamentsScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/VersesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/bible/VersesScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.bible
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/home/HomeViewModel.kt
@@ -2,6 +2,8 @@ package md.ortodox.ortodoxmd.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,7 +44,6 @@ class HomeViewModel @Inject constructor(
 
     // Datele se vor reîncărca de fiecare dată când ecranul devine activ
     override fun onStart(owner: LifecycleOwner) {
-        super.onStart(owner)
         loadHomeScreenData()
     }
 

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconsScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/icons/IconsScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.icons
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryDetailScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryDetailScreen.kt
@@ -96,7 +96,7 @@ fun MonasteryDetailScreen(
                             if (mapIntent.resolveActivity(context.packageManager) != null) {
                                 context.startActivity(mapIntent)
                             } else {
-                                Toast.makeText(context, stringResource(R.string.no_maps_app_found), Toast.LENGTH_LONG).show()
+                                Toast.makeText(context, context.getString(R.string.no_maps_app_found), Toast.LENGTH_LONG).show()
                             }
                         },
                     elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryListScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/monastery/MonasteryListScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.monastery
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerCategoriesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/prayer/PrayerCategoriesScreen.kt
@@ -61,7 +61,7 @@ fun PrayerCategoriesScreen(
                     elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
                 ) {
                     Text(
-                        text = category.title,
+                        text = stringResource(category.titleRes),
                         style = MaterialTheme.typography.titleLarge,
                         modifier = Modifier
                             .padding(16.dp)

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/radio/RadioScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/radio/RadioScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.radio
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/sacrament/SacramentScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/sacrament/SacramentScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.sacrament
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/md/ortodox/ortodoxmd/ui/saints/SaintLivesScreen.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/ui/saints/SaintLivesScreen.kt
@@ -1,4 +1,5 @@
 package md.ortodox.ortodoxmd.ui.saints
+import md.ortodox.ortodoxmd.R
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn


### PR DESCRIPTION
## Summary
- add missing app resource imports across UI screens
- correct DataStore language preference editing and lifecycle handling
- use context strings outside composables and resolve prayer category titles

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bb8b00c88324a8496370818ef467