### PR TITLE
Ensure language preferences are initialized before use

### DIFF
--- a/app/src/main/java/md/ortodox/ortodoxmd/MainActivity.kt
+++ b/app/src/main/java/md/ortodox/ortodoxmd/MainActivity.kt
@@ -135,11 +135,11 @@ class MainActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.O)
     @androidx.annotation.OptIn(UnstableApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         runBlocking {
             val lang = languagePreferences.language.first()
             LocaleHelper.applyLanguage(this@MainActivity, lang)
         }
-        super.onCreate(savedInstanceState)
         askPermissions()
         startService(Intent(this, PlaybackService::class.java))
         enableEdgeToEdge()


### PR DESCRIPTION
## Summary
- Inject language preferences by calling `super.onCreate` before accessing them
- Apply user-selected locale after the activity is created

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c26dc8ac832483bf6e8195486a5c